### PR TITLE
Fix tests to handle matrix workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
     if: |
           github.event_name == 'workflow_dispatch' ||
           github.event.pull_request.head.repo.full_name == github.repository ||
-          contains(github.event.pull_request.labels.*.name, 'ok-to-test')    
+          contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -94,7 +94,7 @@ jobs:
           TOWER_HOST: ${{ secrets.TOWER_HOST }}
           TOWER_OAUTH_TOKEN: ${{ secrets.TOWER_OAUTH_TOKEN }}
           TOWER_PLATFORM: "awx"
-        run: go test -v -cover -tags=${{ vars.BUILD_TAG }} -timeout 20m ./internal/provider/
+        run: go test -v -failfast -cover -tags=${{ vars.BUILD_TAG }} -timeout 20m ./internal/provider/
         timeout-minutes: 20
 
   testaap24:
@@ -103,7 +103,7 @@ jobs:
     if: |
           github.event_name == 'workflow_dispatch' ||
           github.event.pull_request.head.repo.full_name == github.repository ||
-          contains(github.event.pull_request.labels.*.name, 'ok-to-test')    
+          contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -131,5 +131,5 @@ jobs:
           TOWER_OAUTH_TOKEN: ${{ secrets.AAP_24_OAUTH_TOKEN }}
           TOWER_API_RETRY_COUNT: 1 # Run aap2.4 test with API_RETRY_COUNT
           TOWER_API_RETRY_DELAY_SECONDS: 2 # Run aap2.4 test with API_RETRY_DELAY_SECONDS
-        run: go test -v -cover -tags=${{ vars.BUILD_TAG }} -skip "TestAccRoleDefinitionResource|TestAccRoleDefinitionDataSource|TestAccRoleUserAssignmentResource|TestAccRoleTeamAssignmentResource" -timeout 20m ./internal/provider/ # Exclude test incompatible with aap2.4
+        run: go test -v -failfast -cover -tags=${{ vars.BUILD_TAG }} -skip "TestAccRoleDefinitionResource|TestAccRoleDefinitionDataSource|TestAccRoleUserAssignmentResource|TestAccRoleTeamAssignmentResource" -timeout 20m ./internal/provider/ # Exclude test incompatible with aap2.4
         timeout-minutes: 20

--- a/internal/provider/resource_credential_type_test.go
+++ b/internal/provider/resource_credential_type_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccCredentialTypeResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	resource1 := CredentialTypeAPIModel{
 		Name:        "test-credential-type-" + acctest.RandString(5),
 		Description: "test description 1",
@@ -32,45 +33,45 @@ func TestAccCredentialTypeResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCredentialTypeConfig(resource1),
+				Config: testAccCredentialTypeConfig(resource1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("kind"),
 						knownvalue.StringExact(resource1.Kind),
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccCredentialTypeConfig(resource2),
+				Config: testAccCredentialTypeConfig(resource2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_credential_type.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential_type.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("kind"),
 						knownvalue.StringExact(resource1.Kind),
 					),
@@ -80,11 +81,11 @@ func TestAccCredentialTypeResource(t *testing.T) {
 	})
 }
 
-func testAccCredentialTypeConfig(resource CredentialTypeAPIModel) string {
+func testAccCredentialTypeConfig(resource CredentialTypeAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_credential_type" "test" {
+resource "%[1]s_credential_type" "%[4]s" {
   name         = "%[2]s"
   description  = "%[3]s"
 }
-  `, configprefix.Prefix, resource.Name, resource.Description)
+  `, configprefix.Prefix, resource.Name, resource.Description, rName)
 }

--- a/internal/provider/resource_execution_environment_test.go
+++ b/internal/provider/resource_execution_environment_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccExecutionEnvironmentResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	r2Name := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource1 := ExecutionEnvironmentAPIModel{
 		Name:        "test-ee-" + acctest.RandString(5),
@@ -37,62 +39,62 @@ func TestAccExecutionEnvironmentResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExecutionEnvironmentResource1Config(resource1),
+				Config: testAccExecutionEnvironmentResource1Config(resource1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("image"),
 						knownvalue.StringExact(resource1.Image),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("pull"),
 						knownvalue.StringExact(resource1.Pull),
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccExecutionEnvironmentResource2Config(resource2),
+				Config: testAccExecutionEnvironmentResource2Config(resource2, r2Name),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, r2Name),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, r2Name),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, r2Name),
 						tfjsonpath.New("image"),
 						knownvalue.StringExact(resource2.Image),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, r2Name),
 						tfjsonpath.New("pull"),
 						knownvalue.StringExact(resource2.Pull),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_credential.test", configprefix.Prefix),
+						fmt.Sprintf("%s_credential.%s", configprefix.Prefix, r2Name),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_execution_environment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_execution_environment.%s", configprefix.Prefix, r2Name),
 						tfjsonpath.New("credential"),
 						IdCompare,
 					),
@@ -102,30 +104,30 @@ func TestAccExecutionEnvironmentResource(t *testing.T) {
 	})
 }
 
-func testAccExecutionEnvironmentResource1Config(resource ExecutionEnvironmentAPIModel) string {
+func testAccExecutionEnvironmentResource1Config(resource ExecutionEnvironmentAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_execution_environment" "test" {
+resource "%[1]s_execution_environment" "%[6]s" {
   name        	= "%[2]s"
   description 	= "%[3]s"
   image   		= "%[4]s"
   pull 			= "%[5]s"
 }
-  `, configprefix.Prefix, resource.Name, resource.Description, resource.Image, resource.Pull)
+  `, configprefix.Prefix, resource.Name, resource.Description, resource.Image, resource.Pull, rName)
 }
 
-func testAccExecutionEnvironmentResource2Config(resource ExecutionEnvironmentAPIModel) string {
+func testAccExecutionEnvironmentResource2Config(resource ExecutionEnvironmentAPIModel, rName string) string {
 	return fmt.Sprintf(`
-data "%[1]s_credential_type" "test" {
+data "%[1]s_credential_type" "%[7]s" {
   name = "Container Registry"
   kind = "registry"
 }
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[7]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_credential" "test" {
+resource "%[1]s_credential" "%[7]s" {
   name            = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test.id
+  organization    = %[1]s_organization.%[7]s.id
+  credential_type = data.%[1]s_credential_type.%[7]s.id
   inputs = jsonencode({
 	"host" : "quay.io",
 	"username" : "test",
@@ -133,12 +135,12 @@ resource "%[1]s_credential" "test" {
 	"verify_ssl" : true
   })
 }
-resource "%[1]s_execution_environment" "test" {
+resource "%[1]s_execution_environment" "%[7]s" {
   name        	= "%[3]s"
   description 	= "%[4]s"
   image   		= "%[5]s"
   pull 			= "%[6]s"
-  credential	= %[1]s_credential.test.id
+  credential	= %[1]s_credential.%[7]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Image, resource.Pull)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Image, resource.Pull, rName)
 }

--- a/internal/provider/resource_host_test.go
+++ b/internal/provider/resource_host_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccHostResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	host1 := HostAPIModel{
 		Name:        "test-host-" + acctest.RandString(5),
 		Description: "Example with jsonencoded variables for localhost",
@@ -35,55 +36,55 @@ func TestAccHostResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHostResourceConfig1(host1),
+				Config: testAccHostResourceConfig1(host1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(host1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(host1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("variables"),
 						knownvalue.StringExact(host1.Variables),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("enabled"),
 						knownvalue.Bool(host1.Enabled),
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_host.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccHostResourceConfig2(host2),
+				Config: testAccHostResourceConfig2(host2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(host2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(host2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("variables"),
 						knownvalue.StringExact("---"),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_host.test", configprefix.Prefix),
+						fmt.Sprintf("%s_host.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("enabled"),
 						knownvalue.Bool(host2.Enabled),
 					),
@@ -93,43 +94,43 @@ func TestAccHostResource(t *testing.T) {
 	})
 }
 
-func testAccHostResourceConfig1(resource HostAPIModel) string {
+func testAccHostResourceConfig1(resource HostAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[7]s" {
   name        = "test-organization-%[2]s"
   description = "test"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[7]s" {
   name         = "test-inventory-%[2]s"
   description  = "test"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[7]s.id
 }
-resource "%[1]s_host" "test" {
+resource "%[1]s_host" "%[7]s" {
   name        = "%[3]s"
   description = "%[4]s"
-  inventory   = %[1]s_inventory.test.id
+  inventory   = %[1]s_inventory.%[7]s.id
   variables   = jsonencode(%[5]s)
   enabled     = %[6]v
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Variables, resource.Enabled)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Variables, resource.Enabled, rName)
 }
 
-func testAccHostResourceConfig2(resource HostAPIModel) string {
+func testAccHostResourceConfig2(resource HostAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[6]s" {
   name        = "test-organization-%[2]s"
   description = "test"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[6]s" {
   name         = "test-inventory-%[2]s"
   description  = "test"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[6]s.id
 }
-resource "%[1]s_host" "test" {
+resource "%[1]s_host" "%[6]s" {
   name        = "%[3]s"
   description = "%[4]s"
-  inventory   = %[1]s_inventory.test.id
+  inventory   = %[1]s_inventory.%[6]s.id
   enabled     = %[5]v
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Enabled)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Enabled, rName)
 }

--- a/internal/provider/resource_inventory_source_test.go
+++ b/internal/provider/resource_inventory_source_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccInventorySourceResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	inventory_source1 := InventorySourceAPIModel{
 		Name:                 "test-inventory-source-" + acctest.RandString(5),
@@ -41,113 +43,113 @@ func TestAccInventorySourceResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInventorySourceResource1Config(inventory_source1),
+				Config: testAccInventorySourceResource1Config(inventory_source1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(inventory_source1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(inventory_source1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("source"),
 						knownvalue.StringExact(inventory_source1.Source),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("source_path"),
 						knownvalue.StringExact(inventory_source1.SourcePath),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("overwrite"),
 						knownvalue.Bool(inventory_source1.Overwrite),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("overwrite_vars"),
 						knownvalue.Bool(inventory_source1.OverwriteVars),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("update_on_launch"),
 						knownvalue.Bool(inventory_source1.UpdateOnLaunch),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("source_project"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInventorySourceResource2Config(inventory_source2),
+				Config: testAccInventorySourceResource2Config(inventory_source2, rName2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(inventory_source2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(inventory_source2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("source"),
 						knownvalue.StringExact(inventory_source2.Source),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("source_path"),
 						knownvalue.StringExact(inventory_source2.SourcePath),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("overwrite"),
 						knownvalue.Bool(inventory_source2.Overwrite),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("overwrite_vars"),
 						knownvalue.Bool(inventory_source2.OverwriteVars),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("update_on_launch"),
 						knownvalue.Bool(inventory_source2.UpdateOnLaunch),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory_source.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory_source.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("source_project"),
 						IdCompare,
 					),
@@ -157,67 +159,67 @@ func TestAccInventorySourceResource(t *testing.T) {
 	})
 }
 
-func testAccInventorySourceResource1Config(resource InventorySourceAPIModel) string {
+func testAccInventorySourceResource1Config(resource InventorySourceAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[11]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[11]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[11]s.id
   scm_type     = "git"
   scm_url      = "git@github.com:user/repo.git"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[11]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[11]s.id
 }
 
-resource "%[1]s_inventory_source" "test" {
+resource "%[1]s_inventory_source" "%[11]s" {
   name             		= "%[3]s"
   description	   		= "%[4]s"
-  inventory        		= %[1]s_inventory.test.id
+  inventory        		= %[1]s_inventory.%[11]s.id
   source           		= "%[5]s"
-  source_project   		= %[1]s_project.test.id
+  source_project   		= %[1]s_project.%[11]s.id
   source_path      		= "%[6]s"
   overwrite        		= %[7]v
   overwrite_vars   		= %[8]v
   update_on_launch 		= %[9]v
   execution_environment = %[10]v
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Source, resource.SourcePath, resource.Overwrite, resource.OverwriteVars, resource.UpdateOnLaunch, resource.ExecutionEnvironment)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Source, resource.SourcePath, resource.Overwrite, resource.OverwriteVars, resource.UpdateOnLaunch, resource.ExecutionEnvironment, rName)
 }
 
-func testAccInventorySourceResource2Config(resource InventorySourceAPIModel) string {
+func testAccInventorySourceResource2Config(resource InventorySourceAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[10]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[10]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[10]s.id
   scm_type     = "git"
   scm_url      = "git@github.com:user/repo.git"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[10]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[10]s.id
 }
 
-resource "%[1]s_inventory_source" "test" {
+resource "%[1]s_inventory_source" "%[10]s" {
   name             		= "%[3]s"
   description	   		= "%[4]s"
-  inventory        		= %[1]s_inventory.test.id
+  inventory        		= %[1]s_inventory.%[10]s.id
   source           		= "%[5]s"
-  source_project   		= %[1]s_project.test.id
+  source_project   		= %[1]s_project.%[10]s.id
   source_path      		= "%[6]s"
   overwrite        		= %[7]v
   overwrite_vars   		= %[8]v
   update_on_launch 		= %[9]v
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Source, resource.SourcePath, resource.Overwrite, resource.OverwriteVars, resource.UpdateOnLaunch)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Source, resource.SourcePath, resource.Overwrite, resource.OverwriteVars, resource.UpdateOnLaunch, rName)
 }

--- a/internal/provider/resource_inventory_test.go
+++ b/internal/provider/resource_inventory_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestAccInventoryResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName3 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource1 := InventoryAPIModel{
 		Name:        "test-inventory-" + acctest.RandString(5),
@@ -41,116 +44,116 @@ func TestAccInventoryResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInventoryResource1Config(resource1),
+				Config: testAccInventoryResource1Config(resource1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("variables"),
 						knownvalue.StringExact(resource1.Variables),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("kind"),
 						knownvalue.Null(),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("host_filter"),
 						knownvalue.Null(),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccInventoryResource1Config(resource2),
+				Config: testAccInventoryResource1Config(resource2, rName2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("variables"),
 						knownvalue.StringExact(resource2.Variables),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("kind"),
 						knownvalue.Null(),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("host_filter"),
 						knownvalue.Null(),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				Config: testAccInventoryResource3Config(resource3),
+				Config: testAccInventoryResource3Config(resource3, rName3),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource3.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource3.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("variables"),
 						knownvalue.StringExact(resource3.Variables),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("kind"),
 						knownvalue.StringExact(resource3.Kind),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_inventory.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("host_filter"),
 						knownvalue.StringExact(resource3.HostFilter),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_inventory.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
@@ -160,32 +163,32 @@ func TestAccInventoryResource(t *testing.T) {
 	})
 }
 
-func testAccInventoryResource1Config(resource InventoryAPIModel) string {
+func testAccInventoryResource1Config(resource InventoryAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[6]s" {
   name        			= "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[6]s" {
   name         = "%[3]s"
   description  = "%[4]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[6]s.id
   variables    = jsonencode(%[5]s)
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Variables)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Variables, rName)
 }
 
-func testAccInventoryResource3Config(resource InventoryAPIModel) string {
+func testAccInventoryResource3Config(resource InventoryAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test3" {
+resource "%[1]s_organization" "%[8]s" {
   name        			= "%[2]s"
 }
-resource "%[1]s_inventory" "test3" {
+resource "%[1]s_inventory" "%[8]s" {
   name         	= "%[3]s"
   description  	= "%[4]s"
-  organization 	= %[1]s_organization.test3.id
+  organization 	= %[1]s_organization.%[8]s.id
   variables    	= jsonencode(%[5]s)
   kind			= "%[6]s"
   host_filter	= "%[7]s"
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Variables, resource.Kind, resource.HostFilter)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.Variables, resource.Kind, resource.HostFilter, rName)
 }

--- a/internal/provider/resource_job_template_credential_test.go
+++ b/internal/provider/resource_job_template_credential_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccJobTemplateCredentialResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -22,31 +23,31 @@ func TestAccJobTemplateCredentialResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplateCredentialResource1Config(),
+				Config: testAccJobTemplateCredentialResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_credential.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_credential.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_job_template_credential.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_job_template_credential.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_credential.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_credential.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("job_template_id"),
 			},
 			{
-				Config: testAccJobTemplateCredentialResource2Config(),
+				Config: testAccJobTemplateCredentialResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_credential.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_credential.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
@@ -56,104 +57,104 @@ func TestAccJobTemplateCredentialResource(t *testing.T) {
 	})
 }
 
-func testAccJobTemplateCredentialResource1Config() string {
+func testAccJobTemplateCredentialResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-data "%[1]s_credential_type" "test" {
+data "%[1]s_credential_type" "%[3]s" {
   name = "Machine"
   kind = "ssh"
 }
-resource "%[1]s_credential" "test" {
+resource "%[1]s_credential" "%[3]s" {
   name            = "%[2]s"
   description	  = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test.id
+  organization    = %[1]s_organization.%[3]s.id
+  credential_type = data.%[1]s_credential_type.%[3]s.id
   inputs = jsonencode({
     "password" : "%[2]s",
     "username" : "%[2]s"
   })
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "%[2]s"
 }
-resource "%[1]s_job_template_credential" "test" {
-  credential_ids  = [ %[1]s_credential.test.id ]
-  job_template_id = %[1]s_job_template.test.id
+resource "%[1]s_job_template_credential" "%[3]s" {
+  credential_ids  = [ %[1]s_credential.%[3]s.id ]
+  job_template_id = %[1]s_job_template.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName)
 }
 
-func testAccJobTemplateCredentialResource2Config() string {
+func testAccJobTemplateCredentialResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-data "%[1]s_credential_type" "test1" {
+data "%[1]s_credential_type" "%[4]s" {
   name = "Machine"
   kind = "ssh"
 }
-resource "%[1]s_credential" "test1" {
+resource "%[1]s_credential" "%[4]s" {
   name            = "%[2]s"
   description	  = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test1.id
+  organization    = %[1]s_organization.%[3]s.id
+  credential_type = data.%[1]s_credential_type.%[4]s.id
   inputs = jsonencode({
     "password" : "%[2]s",
     "username" : "%[2]s"
   })
 }
-data "%[1]s_credential_type" "test2" {
+data "%[1]s_credential_type" "%[5]s" {
   name = "Amazon Web Services"
   kind = "cloud"
 }
-resource "%[1]s_credential" "test2" {
+resource "%[1]s_credential" "%[5]s" {
   name            = "%[2]s"
   description	  = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test2.id
+  organization    = %[1]s_organization.%[3]s.id
+  credential_type = data.%[1]s_credential_type.%[5]s.id
   inputs = jsonencode({
     "password" : "%[2]s",
     "username" : "%[2]s"
   })
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "%[2]s"
 }
-resource "%[1]s_job_template_credential" "test" {
-  credential_ids  = [ %[1]s_credential.test1.id, %[1]s_credential.test2.id ]
-  job_template_id = %[1]s_job_template.test.id
+resource "%[1]s_job_template_credential" "%[3]s" {
+  credential_ids  = [ %[1]s_credential.%[4]s.id, %[1]s_credential.%[5]s.id ]
+  job_template_id = %[1]s_job_template.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }

--- a/internal/provider/resource_job_template_instance_group_test.go
+++ b/internal/provider/resource_job_template_instance_group_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccJobTemplateInstanceGroupResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -22,31 +23,31 @@ func TestAccJobTemplateInstanceGroupResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplateInstanceGroupResource1Config(),
+				Config: testAccJobTemplateInstanceGroupResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_instance_group.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_instance_group.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_job_template_instance_group.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_job_template_instance_group.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_instance_group.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_instance_group.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("job_template_id"),
 			},
 			{
-				Config: testAccJobTemplateInstanceGroupResource2Config(),
+				Config: testAccJobTemplateInstanceGroupResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_instance_group.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_instance_group.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
@@ -56,71 +57,71 @@ func TestAccJobTemplateInstanceGroupResource(t *testing.T) {
 	})
 }
 
-func testAccJobTemplateInstanceGroupResource1Config() string {
+func testAccJobTemplateInstanceGroupResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_instance_group" "test" {
+resource "%[1]s_instance_group" "%[3]s" {
   name                       = "%[2]s"
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "%[2]s"
 }
-resource "%[1]s_job_template_instance_group" "test" {
-  instance_groups_ids  = [ %[1]s_instance_group.test.id ]
-  job_template_id      = %[1]s_job_template.test.id
+resource "%[1]s_job_template_instance_group" "%[3]s" {
+  instance_groups_ids  = [ %[1]s_instance_group.%[3]s.id ]
+  job_template_id      = %[1]s_job_template.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName)
 }
 
-func testAccJobTemplateInstanceGroupResource2Config() string {
+func testAccJobTemplateInstanceGroupResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_instance_group" "test1" {
+resource "%[1]s_instance_group" "%[4]s" {
   name                       = "%[2]s-1"
 }
-resource "%[1]s_instance_group" "test2" {
+resource "%[1]s_instance_group" "%[5]s" {
   name                       = "%[2]s-2"
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "%[2]s"
 }
-resource "%[1]s_job_template_instance_group" "test" {
-  instance_groups_ids  = [ %[1]s_instance_group.test1.id, %[1]s_instance_group.test2.id ]
-  job_template_id      = %[1]s_job_template.test.id
+resource "%[1]s_job_template_instance_group" "%[3]s" {
+  instance_groups_ids  = [ %[1]s_instance_group.%[4]s.id, %[1]s_instance_group.%[5]s.id ]
+  job_template_id      = %[1]s_job_template.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }

--- a/internal/provider/resource_job_template_label_test.go
+++ b/internal/provider/resource_job_template_label_test.go
@@ -26,65 +26,65 @@ func TestAccJobTemplateLabel_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplateLabel1Config(testingJobTemplateName),
+				Config: testAccJobTemplateLabel1Config(testingJobTemplateName, testingJobTemplateName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_label.test_label_1", configprefix.Prefix),
+						fmt.Sprintf("%s_label.%s", configprefix.Prefix, testingJobTemplateName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_label.%s", configprefix.Prefix, testingJobTemplateName),
 						tfjsonpath.New("label_ids"),
 						stringListComparer,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, testingJobTemplateName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_label.%s", configprefix.Prefix, testingJobTemplateName),
 						tfjsonpath.New("job_template_id"),
 						compare.ValuesSame(),
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_job_template_label.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_job_template_label.%s", configprefix.Prefix, testingJobTemplateName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_label.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_label.%s", configprefix.Prefix, testingJobTemplateName)),
 				ImportStateVerifyIdentifierAttribute: ("job_template_id"),
 			},
 		},
 	})
 }
 
-func testAccJobTemplateLabel1Config(jobTemplateName string) string {
+func testAccJobTemplateLabel1Config(jobTemplateName string, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[4]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[4]s" {
 	name         = "%[2]s"
-	organization = %[1]s_organization.test.id
+	organization = %[1]s_organization.%[4]s.id
 	allow_override = true
 	scm_type = "git"
 	scm_url = "https://github.com/fakerepo"
 }	
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[4]s" {
 	name = "%[3]s"
 	playbook = "hello_world.yml"
 	ask_inventory_on_launch = true
-	project = %[1]s_project.test.id
+	project = %[1]s_project.%[4]s.id
 }
 
-resource "%[1]s_label" "test_label_1" {
+resource "%[1]s_label" "%[5]s" {
 	name = "testlabel1"
-	organization = %[1]s_organization.test.id
+	organization = %[1]s_organization.%[4]s.id
 }
 
-resource "%[1]s_job_template_label" "test" {
-	job_template_id = %[1]s_job_template.test.id
-	label_ids = [%[1]s_label.test_label_1.id]
+resource "%[1]s_job_template_label" "%[4]s" {
+	job_template_id = %[1]s_job_template.%[4]s.id
+	label_ids = [%[1]s_label.%[5]s.id]
 }
 
-  `, configprefix.Prefix, acctest.RandString(5), jobTemplateName)
+  `, configprefix.Prefix, acctest.RandString(5), jobTemplateName, rName, rName+"a")
 }

--- a/internal/provider/resource_job_template_notification_template_error_test.go
+++ b/internal/provider/resource_job_template_notification_template_error_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccJobTemplNotifErrResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,52 +24,52 @@ func TestAccJobTemplNotifErrResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplNotifErr1ResourceConfig(),
+				Config: testAccJobTemplNotifErr1ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("job_template_id"),
 			},
 			{
-				Config: testAccJobTemplNotifErr2ResourceConfig(),
+				Config: testAccJobTemplNotifErr2ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
@@ -78,36 +79,36 @@ func TestAccJobTemplNotifErrResource(t *testing.T) {
 	})
 }
 
-func testAccJobTemplNotifErr1ResourceConfig() string {
+func testAccJobTemplNotifErr1ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "test.yml"
 }
-resource "%[1]s_notification_template" "test1" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -146,43 +147,43 @@ resource "%[1]s_notification_template" "test1" {
     }
   })
 }
-resource "%[1]s_job_template_notification_template_error" "test" {
-  job_template_id    = %[1]s_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test1.id]
+resource "%[1]s_job_template_notification_template_error" "%[3]s" {
+  job_template_id    = %[1]s_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a")
 }
 
-func testAccJobTemplNotifErr2ResourceConfig() string {
+func testAccJobTemplNotifErr2ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "test.yml"
 }
-resource "%[1]s_notification_template" "test2" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s-2"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -221,10 +222,10 @@ resource "%[1]s_notification_template" "test2" {
     }
   })
 }
-resource "%[1]s_notification_template" "test3" {
+resource "%[1]s_notification_template" "%[5]s" {
   name              = "%[2]s-3"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -263,9 +264,9 @@ resource "%[1]s_notification_template" "test3" {
     }
   })
 }
-resource "%[1]s_job_template_notification_template_error" "test" {
-  job_template_id    = %[1]s_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test2.id, %[1]s_notification_template.test3.id]
+resource "%[1]s_job_template_notification_template_error" "%[3]s" {
+  job_template_id    = %[1]s_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id, %[1]s_notification_template.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"b", rName+"c")
 }

--- a/internal/provider/resource_job_template_notification_template_started_test.go
+++ b/internal/provider/resource_job_template_notification_template_started_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccJobTemplNotifStartedResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,52 +24,52 @@ func TestAccJobTemplNotifStartedResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplNotifStarted1ResourceConfig(),
+				Config: testAccJobTemplNotifStarted1ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("job_template_id"),
 			},
 			{
-				Config: testAccJobTemplNotifStarted2ResourceConfig(),
+				Config: testAccJobTemplNotifStarted2ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
@@ -78,36 +79,36 @@ func TestAccJobTemplNotifStartedResource(t *testing.T) {
 	})
 }
 
-func testAccJobTemplNotifStarted1ResourceConfig() string {
+func testAccJobTemplNotifStarted1ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "test.yml"
 }
-resource "%[1]s_notification_template" "test1" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -146,43 +147,43 @@ resource "%[1]s_notification_template" "test1" {
     }
   })
 }
-resource "%[1]s_job_template_notification_template_started" "test" {
-  job_template_id    = %[1]s_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test1.id]
+resource "%[1]s_job_template_notification_template_started" "%[3]s" {
+  job_template_id    = %[1]s_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a")
 }
 
-func testAccJobTemplNotifStarted2ResourceConfig() string {
+func testAccJobTemplNotifStarted2ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "test.yml"
 }
-resource "%[1]s_notification_template" "test2" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s-2"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -221,10 +222,10 @@ resource "%[1]s_notification_template" "test2" {
     }
   })
 }
-resource "%[1]s_notification_template" "test3" {
+resource "%[1]s_notification_template" "%[5]s" {
   name              = "%[2]s-3"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -263,9 +264,9 @@ resource "%[1]s_notification_template" "test3" {
     }
   })
 }
-resource "%[1]s_job_template_notification_template_started" "test" {
-  job_template_id    = %[1]s_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test2.id, %[1]s_notification_template.test3.id]
+resource "%[1]s_job_template_notification_template_started" "%[3]s" {
+  job_template_id    = %[1]s_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id, %[1]s_notification_template.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"b", rName+"c")
 }

--- a/internal/provider/resource_job_template_notification_template_success_test.go
+++ b/internal/provider/resource_job_template_notification_template_success_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccJobTemplNotifSuccessResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,52 +24,52 @@ func TestAccJobTemplNotifSuccessResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplNotifSuccess1ResourceConfig(),
+				Config: testAccJobTemplNotifSuccess1ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("job_template_id"),
 			},
 			{
-				Config: testAccJobTemplNotifSuccess2ResourceConfig(),
+				Config: testAccJobTemplNotifSuccess2ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template_notification_template_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template_notification_template_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
@@ -78,36 +79,36 @@ func TestAccJobTemplNotifSuccessResource(t *testing.T) {
 	})
 }
 
-func testAccJobTemplNotifSuccess1ResourceConfig() string {
+func testAccJobTemplNotifSuccess1ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "test.yml"
 }
-resource "%[1]s_notification_template" "test1" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -146,43 +147,43 @@ resource "%[1]s_notification_template" "test1" {
     }
   })
 }
-resource "%[1]s_job_template_notification_template_success" "test" {
-  job_template_id    = %[1]s_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test1.id]
+resource "%[1]s_job_template_notification_template_success" "%[3]s" {
+  job_template_id    = %[1]s_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a")
 }
 
-func testAccJobTemplNotifSuccess2ResourceConfig() string {
+func testAccJobTemplNotifSuccess2ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[3]s.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "test.yml"
 }
-resource "%[1]s_notification_template" "test2" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s-2"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -221,10 +222,10 @@ resource "%[1]s_notification_template" "test2" {
     }
   })
 }
-resource "%[1]s_notification_template" "test3" {
+resource "%[1]s_notification_template" "%[5]s" {
   name              = "%[2]s-3"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -263,9 +264,9 @@ resource "%[1]s_notification_template" "test3" {
     }
   })
 }
-resource "%[1]s_job_template_notification_template_success" "test" {
-  job_template_id    = %[1]s_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test2.id, %[1]s_notification_template.test3.id]
+resource "%[1]s_job_template_notification_template_success" "%[3]s" {
+  job_template_id    = %[1]s_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id, %[1]s_notification_template.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"b", rName+"c")
 }

--- a/internal/provider/resource_job_template_test.go
+++ b/internal/provider/resource_job_template_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccJobTemplateResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource1 := JobTemplateAPIModel{
 		Name:        "test-job-template-" + acctest.RandString(5),
@@ -35,83 +36,83 @@ func TestAccJobTemplateResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccJobTemplateResourceConfig(resource1),
+				Config: testAccJobTemplateResourceConfig(resource1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_type"),
 						knownvalue.StringExact(resource1.JobType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("playbook"),
 						knownvalue.StringExact(resource1.Playbook),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("project"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccJobTemplateResourceConfig(resource2),
+				Config: testAccJobTemplateResourceConfig(resource2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("job_type"),
 						knownvalue.StringExact(resource2.JobType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("playbook"),
 						knownvalue.StringExact(resource2.Playbook),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("project"),
 						IdCompare,
 					),
@@ -121,32 +122,32 @@ func TestAccJobTemplateResource(t *testing.T) {
 	})
 }
 
-func testAccJobTemplateResourceConfig(resource JobTemplateAPIModel) string {
+func testAccJobTemplateResourceConfig(resource JobTemplateAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[7]s" {
   name        = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[7]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[7]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[7]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[7]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[7]s" {
   name        = "%[3]s"
   description = "%[4]s"
   job_type    = "%[5]s"
-  inventory   = %[1]s_inventory.test.id
-  project     = %[1]s_project.test.id
+  inventory   = %[1]s_inventory.%[7]s.id
+  project     = %[1]s_project.%[7]s.id
   playbook    = "%[6]s"
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.JobType, resource.Playbook)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.JobType, resource.Playbook, rName)
 }

--- a/internal/provider/resource_label_test.go
+++ b/internal/provider/resource_label_test.go
@@ -16,6 +16,7 @@ import (
 func TestAccLabel_basic(t *testing.T) {
 	orgName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	labelName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	idComparer := &compareTwoValuesAsStrings{}
 
 	resource.Test(t, resource.TestCase{
@@ -26,24 +27,24 @@ func TestAccLabel_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: labelTestCaseSetup(orgName, labelName),
+				Config: labelTestCaseSetup(orgName, labelName, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.testorg", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, orgName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_label.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("organization"),
 						idComparer,
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_label.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(labelName),
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_label.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_label.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -51,15 +52,15 @@ func TestAccLabel_basic(t *testing.T) {
 	})
 }
 
-func labelTestCaseSetup(org, name string) string {
+func labelTestCaseSetup(org, name string, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "testorg" {
+resource "%[1]s_organization" "%[5]s" {
 	name = "%[2]s"
 }
 
-resource "%[1]s_label" "test" {
+resource "%[1]s_label" "%[4]s" {
 	name = "%[3]s"
-	organization = %[1]s_organization.testorg.id
+	organization = %[1]s_organization.%[5]s.id
 }
-`, configprefix.Prefix, org, name)
+`, configprefix.Prefix, org, name, rName, org)
 }

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestAccProjectResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName3 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName4 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	project1 := ProjectAPIModel{
 		Name:           "test-project-" + acctest.RandString(5),
@@ -64,173 +68,173 @@ func TestAccProjectResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectResourceConfig(project1),
+				Config: testAccProjectResourceConfig(project1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(project1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(project1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("scm_type"),
 						knownvalue.StringExact(project1.ScmType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("scm_url"),
 						knownvalue.StringExact(project1.ScmUrl),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("scm_update_on_launch"),
 						knownvalue.Bool(project1.ScmUpdOnLaunch),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("timeout"),
 						knownvalue.Int32Exact(int32(project1.Timeout)),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_project.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccProjectResourceConfig(project2),
+				Config: testAccProjectResourceConfig(project2, rName2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(project2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(project2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("scm_type"),
 						knownvalue.StringExact(project2.ScmType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("scm_url"),
 						knownvalue.StringExact(project2.ScmUrl),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("scm_update_on_launch"),
 						knownvalue.Bool(project2.ScmUpdOnLaunch),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("timeout"),
 						knownvalue.Int32Exact(int32(project2.Timeout)),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_project.test", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				Config: testAccProjectResource3Config(project3),
+				Config: testAccProjectResource3Config(project3, rName3),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(project3.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(project3.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("scm_type"),
 						knownvalue.StringExact(project3.ScmType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("scm_url"),
 						knownvalue.StringExact(project3.ScmUrl),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("scm_update_on_launch"),
 						knownvalue.Bool(project3.ScmUpdOnLaunch),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("timeout"),
 						knownvalue.Int32Exact(int32(project3.Timeout)),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_project.test-svn", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName3),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				Config: testAccProjectResource4Config(project4),
+				Config: testAccProjectResource4Config(project4, rName4),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(project4.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(project4.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("scm_type"),
 						knownvalue.StringExact(project4.ScmType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("scm_url"),
 						knownvalue.StringExact(project4.ScmUrl),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("scm_update_on_launch"),
 						knownvalue.Bool(project4.ScmUpdOnLaunch),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("timeout"),
 						knownvalue.Int32Exact(int32(project4.Timeout)),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_project.test-archive", configprefix.Prefix),
+						fmt.Sprintf("%s_project.%s", configprefix.Prefix, rName4),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
@@ -240,54 +244,54 @@ func TestAccProjectResource(t *testing.T) {
 	})
 }
 
-func testAccProjectResourceConfig(resource ProjectAPIModel) string {
+func testAccProjectResourceConfig(resource ProjectAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[9]s" {
   name        			= "%[2]s"
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[9]s" {
   name         			= "%[3]s"
   description  			= "%[4]s"
   scm_type     			= "%[5]s"
   scm_url      			= "%[6]s"
-  organization 			= %[1]s_organization.test.id
+  organization 			= %[1]s_organization.%[9]s.id
   scm_update_on_launch 	= %[7]v
   timeout				= %[8]d
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.ScmType, resource.ScmUrl, resource.ScmUpdOnLaunch, resource.Timeout)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.ScmType, resource.ScmUrl, resource.ScmUpdOnLaunch, resource.Timeout, rName)
 }
 
-func testAccProjectResource3Config(resource ProjectAPIModel) string {
+func testAccProjectResource3Config(resource ProjectAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test-svn" {
+resource "%[1]s_organization" "%[9]s" {
   name        			= "%[2]s"
 }
-resource "%[1]s_project" "test-svn" {
+resource "%[1]s_project" "%[9]s" {
   name         			= "%[3]s"
   description  			= "%[4]s"
   scm_type     			= "%[5]s"
   scm_url      			= "%[6]s"
-  organization 			= %[1]s_organization.test-svn.id
+  organization 			= %[1]s_organization.%[9]s.id
   scm_update_on_launch 	= %[7]v
   timeout				= %[8]d
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.ScmType, resource.ScmUrl, resource.ScmUpdOnLaunch, resource.Timeout)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.ScmType, resource.ScmUrl, resource.ScmUpdOnLaunch, resource.Timeout, rName)
 }
 
-func testAccProjectResource4Config(resource ProjectAPIModel) string {
+func testAccProjectResource4Config(resource ProjectAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test-archive" {
+resource "%[1]s_organization" "%[10]s" {
   name        			= "%[2]s"
 }
-resource "%[1]s_project" "test-archive" {
+resource "%[1]s_project" "%[10]s" {
   name         			   = "%[3]s"
   description  			   = "%[4]s"
   scm_type     			   = "%[5]s"
   scm_url      			   = "%[6]s"
-  organization 			   = %[1]s_organization.test-archive.id
+  organization 			   = %[1]s_organization.%[10]s.id
   scm_update_on_launch 	   = %[7]v
   scm_update_cache_timeout = %[8]d
   timeout				   = %[9]d
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.ScmType, resource.ScmUrl, resource.ScmUpdOnLaunch, resource.ScmUpdateCacheTimeout, resource.Timeout)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, resource.ScmType, resource.ScmUrl, resource.ScmUpdOnLaunch, resource.ScmUpdateCacheTimeout, resource.Timeout, rName)
 }

--- a/internal/provider/resource_role_definition_test.go
+++ b/internal/provider/resource_role_definition_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccRoleDefinitionResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	RoleDefinition1 := RoleDefinitionAPIModel{
 		Name:        "test-group-" + acctest.RandString(5),
 		Description: "Example 1",
@@ -36,20 +37,20 @@ func TestAccRoleDefinitionResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoleDefinitionResourceConfig(RoleDefinition1),
+				Config: testAccRoleDefinitionResourceConfig(RoleDefinition1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(RoleDefinition1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("content_type"),
 						knownvalue.StringExact(RoleDefinition1.ContentType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("permissions"),
 						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact(RoleDefinition1.Permissions[0]),
@@ -59,25 +60,25 @@ func TestAccRoleDefinitionResource(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoleDefinitionResourceConfig(RoleDefinition2),
+				Config: testAccRoleDefinitionResourceConfig(RoleDefinition2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(RoleDefinition2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("content_type"),
 						knownvalue.StringExact(RoleDefinition2.ContentType),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_role_definition.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("permissions"),
 						knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.StringExact(RoleDefinition2.Permissions[0]),
@@ -90,13 +91,13 @@ func TestAccRoleDefinitionResource(t *testing.T) {
 	})
 }
 
-func testAccRoleDefinitionResourceConfig(resource RoleDefinitionAPIModel) string {
+func testAccRoleDefinitionResourceConfig(resource RoleDefinitionAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_role_definition" "test" {
+resource "%[1]s_role_definition" "%[6]s" {
   name         = "%[2]s"
   description  = "Test role definition"
   content_type = "%[3]s"
   permissions   = ["%[4]s", "%[5]s"]
 }
-`, configprefix.Prefix, resource.Name, resource.ContentType, resource.Permissions[0], resource.Permissions[1])
+`, configprefix.Prefix, resource.Name, resource.ContentType, resource.Permissions[0], resource.Permissions[1], rName)
 }

--- a/internal/provider/resource_role_team_assignment_test.go
+++ b/internal/provider/resource_role_team_assignment_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccRoleTeamAssignmentResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 
 	resource.Test(t, resource.TestCase{
@@ -23,57 +24,57 @@ func TestAccRoleTeamAssignmentResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoleTeamAssignmentResourceConfig(1),
+				Config: testAccRoleTeamAssignmentResourceConfig(1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("object_id"),
-						fmt.Sprintf("%s_organization.test-1", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName+"-1"),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("role_definition"),
-						fmt.Sprintf("%s_role_definition.test-1", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName+"-1"),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("team"),
-						fmt.Sprintf("%s_team.test-1", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName+"-1"),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoleTeamAssignmentResourceConfig(2),
+				Config: testAccRoleTeamAssignmentResourceConfig(2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("object_id"),
-						fmt.Sprintf("%s_organization.test-2", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName+"-2"),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("role_definition"),
-						fmt.Sprintf("%s_role_definition.test-2", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s", configprefix.Prefix, rName+"-2"),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_team_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_team_assignment.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("team"),
-						fmt.Sprintf("%s_team.test-2", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName+"-2"),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
@@ -83,26 +84,26 @@ func TestAccRoleTeamAssignmentResource(t *testing.T) {
 	})
 }
 
-func testAccRoleTeamAssignmentResourceConfig(number int) string {
+func testAccRoleTeamAssignmentResourceConfig(number int, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test-%[3]d" {
+resource "%[1]s_organization" "%[4]s-%[3]d" {
   name        			= "%[2]s-%[3]d"
 }
-resource "%[1]s_role_definition" "test-%[3]d" {
+resource "%[1]s_role_definition" "%[4]s-%[3]d" {
   name         = "%[2]s"
   description  = "Test role definition"
   content_type = "shared.organization"
   permissions   = ["shared.view_organization"]
 }
-resource "%[1]s_team" "test-%[3]d" {
+resource "%[1]s_team" "%[4]s-%[3]d" {
   name      = "%[2]s-%[3]d"
-  organization   = %[1]s_organization.test-%[3]d.id
+  organization   = %[1]s_organization.%[4]s-%[3]d.id
   description  = "%[2]s-%[3]d description"
 }
-resource "%[1]s_role_team_assignment" "test" {
-  object_id       = %[1]s_organization.test-%[3]d.id
-  role_definition = %[1]s_role_definition.test-%[3]d.id
-  team            = %[1]s_team.test-%[3]d.id
+resource "%[1]s_role_team_assignment" "%[4]s" {
+  object_id       = %[1]s_organization.%[4]s-%[3]d.id
+  role_definition = %[1]s_role_definition.%[4]s-%[3]d.id
+  team            = %[1]s_team.%[4]s-%[3]d.id
 }
-`, configprefix.Prefix, acctest.RandString(5), number)
+`, configprefix.Prefix, acctest.RandString(5), number, rName)
 }

--- a/internal/provider/resource_role_user_assignment_test.go
+++ b/internal/provider/resource_role_user_assignment_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestAccRoleUserAssignmentResource(t *testing.T) {
 	IdCompare := &compareTwoValuesAsStrings{}
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -23,57 +24,57 @@ func TestAccRoleUserAssignmentResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoleUserAssignmentResourceConfig(1),
+				Config: testAccRoleUserAssignmentResourceConfig(1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_user_assignment.%s-1", configprefix.Prefix, rName),
 						tfjsonpath.New("object_id"),
-						fmt.Sprintf("%s_organization.test-1", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s-1", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_user_assignment.%s-1", configprefix.Prefix, rName),
 						tfjsonpath.New("role_definition"),
-						fmt.Sprintf("%s_role_definition.test-1", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s-1", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_user_assignment.%s-1", configprefix.Prefix, rName),
 						tfjsonpath.New("user"),
-						fmt.Sprintf("%s_user.test-1", configprefix.Prefix),
+						fmt.Sprintf("%s_user.%s-1", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_role_user_assignment.%s-1", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccRoleUserAssignmentResourceConfig(2),
+				Config: testAccRoleUserAssignmentResourceConfig(2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_user_assignment.%s-2", configprefix.Prefix, rName),
 						tfjsonpath.New("object_id"),
-						fmt.Sprintf("%s_organization.test-2", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s-2", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_user_assignment.%s-2", configprefix.Prefix, rName),
 						tfjsonpath.New("role_definition"),
-						fmt.Sprintf("%s_role_definition.test-2", configprefix.Prefix),
+						fmt.Sprintf("%s_role_definition.%s-2", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_role_user_assignment.test", configprefix.Prefix),
+						fmt.Sprintf("%s_role_user_assignment.%s-2", configprefix.Prefix, rName),
 						tfjsonpath.New("user"),
-						fmt.Sprintf("%s_user.test-2", configprefix.Prefix),
+						fmt.Sprintf("%s_user.%s-2", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
@@ -83,28 +84,28 @@ func TestAccRoleUserAssignmentResource(t *testing.T) {
 	})
 }
 
-func testAccRoleUserAssignmentResourceConfig(number int) string {
+func testAccRoleUserAssignmentResourceConfig(number int, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test-%[3]d" {
+resource "%[1]s_organization" "%[4]s-%[3]d" {
   name        			= "%[2]s-%[3]d"
 }
-resource "%[1]s_role_definition" "test-%[3]d" {
-  name         = "%[2]s"
+resource "%[1]s_role_definition" "%[4]s-%[3]d" {
+  name         = "%[2]s-%[3]d"
   description  = "Test role definition"
   content_type = "shared.organization"
   permissions   = ["shared.member_organization", "shared.view_organization"]
 }
-resource "%[1]s_user" "test-%[3]d" {
+resource "%[1]s_user" "%[4]s-%[3]d" {
   username      = "%[2]s-%[3]d"
   first_name 	= "%[2]s-%[3]d"
   last_name 	= "%[2]s-%[3]d"
   email			= "%[2]s-%[3]d@example.com"
   password 		= "%[2]s-%[3]d-password"
 }
-resource "%[1]s_role_user_assignment" "test" {
-  object_id       = %[1]s_organization.test-%[3]d.id
-  role_definition = %[1]s_role_definition.test-%[3]d.id
-  user            = %[1]s_user.test-%[3]d.id
+resource "%[1]s_role_user_assignment" "%[4]s-%[3]d" {
+  object_id       = %[1]s_organization.%[4]s-%[3]d.id
+  role_definition = %[1]s_role_definition.%[4]s-%[3]d.id
+  user            = %[1]s_user.%[4]s-%[3]d.id
 }
-`, configprefix.Prefix, acctest.RandString(5), number)
+`, configprefix.Prefix, acctest.RandString(5), number, rName)
 }

--- a/internal/provider/resource_schedule_test.go
+++ b/internal/provider/resource_schedule_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccScheduleResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	schedule1 := ScheduleAPIModel{
 		Name:               "test-schedule-" + acctest.RandString(5),
 		Description:        "Initial test schedule",
@@ -38,65 +39,65 @@ func TestAccScheduleResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduleResourceConfig(schedule1),
+				Config: testAccScheduleResourceConfig(schedule1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(schedule1.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(schedule1.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("rrule"),
 						knownvalue.StringExact(schedule1.Rrule),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("unified_job_template"),
 						knownvalue.Int32Exact(int32(schedule1.UnifiedJobTemplate)),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("enabled"),
 						knownvalue.Bool(schedule1.Enabled),
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccScheduleResourceConfig(schedule2),
+				Config: testAccScheduleResourceConfig(schedule2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(schedule2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(schedule2.Description),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("rrule"),
 						knownvalue.StringExact(schedule2.Rrule),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("unified_job_template"),
 						knownvalue.Int32Exact(int32(schedule2.UnifiedJobTemplate)),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_schedule.test", configprefix.Prefix),
+						fmt.Sprintf("%s_schedule.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("enabled"),
 						knownvalue.Bool(schedule2.Enabled),
 					),
@@ -106,14 +107,14 @@ func TestAccScheduleResource(t *testing.T) {
 	})
 }
 
-func testAccScheduleResourceConfig(resource ScheduleAPIModel) string {
+func testAccScheduleResourceConfig(resource ScheduleAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_schedule" "test" {
+resource "%[1]s_schedule" "%[7]s" {
   name        			= "%[2]s"
   description 			= "%[3]s"
   rrule       			= "%[4]s"
   unified_job_template 	= %[5]d
   enabled     			= %[6]t
 }
-  `, configprefix.Prefix, resource.Name, resource.Description, resource.Rrule, resource.UnifiedJobTemplate, resource.Enabled)
+  `, configprefix.Prefix, resource.Name, resource.Description, resource.Rrule, resource.UnifiedJobTemplate, resource.Enabled, rName)
 }

--- a/internal/provider/resource_team_test.go
+++ b/internal/provider/resource_team_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccTeamResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	teamName := "test-team-" + acctest.RandString(5)
 	teamDesc := "Test team description"
@@ -27,49 +28,49 @@ func TestAccTeamResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTeamResourceConfig(teamName, teamDesc),
+				Config: testAccTeamResourceConfig(teamName, teamDesc, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_team.test", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(teamName),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_team.test", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(teamDesc),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("aap25_gateway_id"),
-						fmt.Sprintf("%s_team.test", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_team.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccTeamResourceConfig(teamName, teamDesc2),
+				Config: testAccTeamResourceConfig(teamName, teamDesc2, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_team.test", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(teamName),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_team.test", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(teamDesc2),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("aap25_gateway_id"),
-						fmt.Sprintf("%s_team.test", configprefix.Prefix),
+						fmt.Sprintf("%s_team.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
@@ -79,16 +80,16 @@ func TestAccTeamResource(t *testing.T) {
 	})
 }
 
-func testAccTeamResourceConfig(teamName, teamDesc string) string {
+func testAccTeamResourceConfig(teamName, teamDesc string, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[5]s" {
   name = "%[2]s"
 }
 
-resource "%[1]s_team" "test" {
+resource "%[1]s_team" "%[5]s" {
   name         = "%[3]s"
-  organization = %[1]s_organization.test.aap25_gateway_id
+  organization = %[1]s_organization.%[5]s.aap25_gateway_id
   description  = "%[4]s"
 }
-`, configprefix.Prefix, acctest.RandString(5), teamName, teamDesc)
+`, configprefix.Prefix, acctest.RandString(5), teamName, teamDesc, rName)
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -14,6 +14,11 @@ import (
 )
 
 func TestAccUserResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName3 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName4 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+
 	if configprefix.Prefix == "awx" {
 		resource1 := UserAPIModel{
 			Username:  "test-user-" + acctest.RandString(5),
@@ -54,40 +59,40 @@ func TestAccUserResource(t *testing.T) {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccUserResource1Config(resource1),
+					Config: testAccUserResource1Config(resource1, rName),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource1.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource1.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource1.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource1.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource1.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(false),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("is_system_auditor"),
 							knownvalue.Bool(false),
 						),
@@ -95,47 +100,47 @@ func TestAccUserResource(t *testing.T) {
 				},
 				// ImportState testing
 				{
-					ResourceName:            fmt.Sprintf("%s_user.test", configprefix.Prefix),
+					ResourceName:            fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 					ImportState:             true,
 					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"password"},
 				},
 				// Update and Read testing
 				{
-					Config: testAccUserResource2Config(resource2),
+					Config: testAccUserResource2Config(resource2, rName2),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource2.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource2.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource2.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource2.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource2.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(resource2.IsSuperuser),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("is_system_auditor"),
 							knownvalue.Bool(false),
 						),
@@ -143,40 +148,40 @@ func TestAccUserResource(t *testing.T) {
 				},
 				// Test superuser
 				{
-					Config: testAccUserResource3Config(resource3),
+					Config: testAccUserResource3Config(resource3, rName3),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource3.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource3.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource3.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource3.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource3.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(resource3.IsSuperuser),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("is_system_auditor"),
 							knownvalue.Bool(resource3.IsSystemAuditor),
 						),
@@ -184,40 +189,40 @@ func TestAccUserResource(t *testing.T) {
 				},
 				// Test system auditor
 				{
-					Config: testAccUserResource4Config(resource4),
+					Config: testAccUserResource4Config(resource4, rName4),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource4.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource4.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource4.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource4.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource4.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(resource4.IsSuperuser),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("is_system_auditor"),
 							knownvalue.Bool(resource4.IsSystemAuditor),
 						),
@@ -264,35 +269,35 @@ func TestAccUserResource(t *testing.T) {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: testAccUserResource1Config(resource1),
+					Config: testAccUserResource1Config(resource1, rName),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource1.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource1.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource1.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource1.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource1.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(false),
 						),
@@ -300,42 +305,42 @@ func TestAccUserResource(t *testing.T) {
 				},
 				// ImportState testing
 				{
-					ResourceName:            fmt.Sprintf("%s_user.test", configprefix.Prefix),
+					ResourceName:            fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName),
 					ImportState:             true,
 					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"password"},
 				},
 				// Update and Read testing
 				{
-					Config: testAccUserResource2Config(resource2),
+					Config: testAccUserResource2Config(resource2, rName2),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource2.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource2.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource2.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource2.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource2.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName2),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(resource2.IsSuperuser),
 						),
@@ -343,35 +348,35 @@ func TestAccUserResource(t *testing.T) {
 				},
 				// Test superuser
 				{
-					Config: testAccUserResource3Config(resource3),
+					Config: testAccUserResource3Config(resource3, rName3),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource3.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource3.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource3.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource3.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource3.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-3", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName3),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(resource3.IsSuperuser),
 						),
@@ -379,35 +384,35 @@ func TestAccUserResource(t *testing.T) {
 				},
 				// Test system auditor
 				{
-					Config: testAccUserResource4Config(resource4),
+					Config: testAccUserResource4Config(resource4, rName4),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("username"),
 							knownvalue.StringExact(resource4.Username),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("first_name"),
 							knownvalue.StringExact(resource4.FirstName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("last_name"),
 							knownvalue.StringExact(resource4.LastName),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("email"),
 							knownvalue.StringExact(resource4.Email),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("password"),
 							knownvalue.StringExact(resource4.Password),
 						),
 						statecheck.ExpectKnownValue(
-							fmt.Sprintf("%s_user.test-4", configprefix.Prefix),
+							fmt.Sprintf("%s_user.%s", configprefix.Prefix, rName4),
 							tfjsonpath.New("is_superuser"),
 							knownvalue.Bool(resource4.IsSuperuser),
 						),
@@ -418,34 +423,21 @@ func TestAccUserResource(t *testing.T) {
 	}
 }
 
-func testAccUserResource1Config(resource UserAPIModel) string {
+func testAccUserResource1Config(resource UserAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_user" "test" {
+resource "%[1]s_user" "%[7]s" {
   username      = "%[2]s"
   first_name 	= "%[3]s"
   last_name 	= "%[4]s"
   email			= "%[5]s"
   password 		= "%[6]s"
 }
-  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password)
+  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, rName)
 }
 
-func testAccUserResource2Config(resource UserAPIModel) string {
+func testAccUserResource2Config(resource UserAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_user" "test" {
-  username      = "%[2]s"
-  first_name 	= "%[3]s"
-  last_name 	= "%[4]s"
-  email			= "%[5]s"
-  password 		= "%[6]s"
-  is_superuser  = %[7]v
-}
-  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, resource.IsSuperuser)
-}
-
-func testAccUserResource3Config(resource UserAPIModel) string {
-	return fmt.Sprintf(`
-resource "%[1]s_user" "test-3" {
+resource "%[1]s_user" "%[8]s" {
   username      = "%[2]s"
   first_name 	= "%[3]s"
   last_name 	= "%[4]s"
@@ -453,12 +445,25 @@ resource "%[1]s_user" "test-3" {
   password 		= "%[6]s"
   is_superuser  = %[7]v
 }
-  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, resource.IsSuperuser)
+  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, resource.IsSuperuser, rName)
 }
 
-func testAccUserResource4Config(resource UserAPIModel) string {
+func testAccUserResource3Config(resource UserAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_user" "test-4" {
+resource "%[1]s_user" "%[8]s" {
+  username      = "%[2]s"
+  first_name 	= "%[3]s"
+  last_name 	= "%[4]s"
+  email			= "%[5]s"
+  password 		= "%[6]s"
+  is_superuser  = %[7]v
+}
+  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, resource.IsSuperuser, rName)
+}
+
+func testAccUserResource4Config(resource UserAPIModel, rName string) string {
+	return fmt.Sprintf(`
+resource "%[1]s_user" "%[8]s" {
   username      	= "%[2]s"
   first_name 		= "%[3]s"
   last_name 		= "%[4]s"
@@ -466,5 +471,5 @@ resource "%[1]s_user" "test-4" {
   password 			= "%[6]s"
   is_system_auditor = %[7]v
 }
-  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, resource.IsSystemAuditor)
+  `, configprefix.Prefix, resource.Username, resource.FirstName, resource.LastName, resource.Email, resource.Password, resource.IsSystemAuditor, rName)
 }

--- a/internal/provider/resource_workflow_job_template_approval_node_test.go
+++ b/internal/provider/resource_workflow_job_template_approval_node_test.go
@@ -16,6 +16,7 @@ import (
 func TestAccWkflwJobTemplApprovalNodeResource(t *testing.T) {
 	IdCompare := &compareTwoValuesAsStrings{}
 	nodeName := acctest.RandString(5)
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -25,44 +26,44 @@ func TestAccWkflwJobTemplApprovalNodeResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplApprvlNodeResource1Config(nodeName),
+				Config: testAccWkflwJobTemplApprvlNodeResource1Config(nodeName, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_approval_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_approval_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(nodeName),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_approval_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact("a description for testing"),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_approval_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("timeout"),
 						knownvalue.Int32Exact(360),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_approval_node.test_timeoutdefault", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName+"d"),
 						tfjsonpath.New("timeout"),
 						knownvalue.Int32Exact(0),
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_approval_node.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_approval_node.test_timeoutdefault", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_approval_node.%s", configprefix.Prefix, rName+"d"),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -70,45 +71,45 @@ func TestAccWkflwJobTemplApprovalNodeResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplApprvlNodeResource1Config(nodeName string) string {
+func testAccWkflwJobTemplApprvlNodeResource1Config(nodeName string, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[5]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[5]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[5]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[5]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[5]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[5]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[5]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[5]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[5]s.id
+  organization             = %[1]s_organization.%[5]s.id
 }
 
-resource "%[1]s_workflow_job_template_approval_node" "test" {
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
+resource "%[1]s_workflow_job_template_approval_node" "%[5]s" {
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[5]s.id
   name = "%[3]s"
   description = "a description for testing"
   timeout = 360
 }
 
-resource "%[1]s_workflow_job_template_approval_node" "test_timeoutdefault" {
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
+resource "%[1]s_workflow_job_template_approval_node" "%[6]s" {
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[5]s.id
   name = "%[4]s"
   description = "a description for testing"
 }
-  `, configprefix.Prefix, acctest.RandString(5), nodeName, nodeName+"1")
+  `, configprefix.Prefix, acctest.RandString(5), nodeName, nodeName+"1", rName, rName+"d")
 }

--- a/internal/provider/resource_workflow_job_template_job_node_credential_test.go
+++ b/internal/provider/resource_workflow_job_template_job_node_credential_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWkflwJobTemplJobNodeCredentialResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -22,31 +23,29 @@ func TestAccWkflwJobTemplJobNodeCredentialResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplJobNodeCredentialResource1Config(),
+				Config: testAccWkflwJobTemplJobNodeCredentialResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node_credential.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node_credential.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_job_node_credential.test", configprefix.Prefix),
-				ImportState:                          true,
-				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateJobTemplateID(fmt.Sprintf("%s_job_template_credential.test", configprefix.Prefix)),
-				ImportStateVerifyIdentifierAttribute: ("id"),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_job_node_credential.%s", configprefix.Prefix, rName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWkflwJobTemplJobNodeCredentialResource2Config(),
+				Config: testAccWkflwJobTemplJobNodeCredentialResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node_credential.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node_credential.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
@@ -56,122 +55,127 @@ func TestAccWkflwJobTemplJobNodeCredentialResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplJobNodeCredentialResource1Config() string {
+func testAccWkflwJobTemplJobNodeCredentialResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-data "%[1]s_credential_type" "test" {
+data "%[1]s_credential_type" "%[3]s" {
   name = "Machine"
   kind = "ssh"
 }
-resource "%[1]s_credential" "test" {
+resource "%[1]s_credential" "%[3]s" {
   name            = "%[2]s"
   description	    = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test.id
+  organization    = %[1]s_organization.%[3]s.id
+  credential_type = data.%[1]s_credential_type.%[3]s.id
   inputs = jsonencode({
     "password" : "%[2]s",
     "username" : "%[2]s"
   })
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  project     = %[1]s_project.test.id
+  project     = %[1]s_project.%[3]s.id
+  inventory   = %[1]s_inventory.%[3]s.id
   playbook    = "%[2]s"
+  ask_credential_on_launch = true
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				        = %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[3]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				        = %[1]s_inventory.%[3]s.id
+
 }
-resource "%[1]s_workflow_job_template_job_node_credential" "test" {
-  credential_ids  = [ %[1]s_credential.test.id ]
-  id              = %[1]s_workflow_job_template_job_node.test.id
+resource "%[1]s_workflow_job_template_job_node_credential" "%[3]s" {
+  credential_ids  = [ %[1]s_credential.%[3]s.id ]
+  id              = %[1]s_workflow_job_template_job_node.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }
 
-func testAccWkflwJobTemplJobNodeCredentialResource2Config() string {
+func testAccWkflwJobTemplJobNodeCredentialResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-data "%[1]s_credential_type" "test1" {
+data "%[1]s_credential_type" "%[4]s" {
   name = "Machine"
   kind = "ssh"
 }
-resource "%[1]s_credential" "test1" {
+resource "%[1]s_credential" "%[4]s" {
   name            = "%[2]s"
   description	  = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test1.id
+  organization    = %[1]s_organization.%[3]s.id
+  credential_type = data.%[1]s_credential_type.%[4]s.id
   inputs = jsonencode({
     "password" : "%[2]s",
     "username" : "%[2]s"
   })
 }
-data "%[1]s_credential_type" "test2" {
+data "%[1]s_credential_type" "%[5]s" {
   name = "Amazon Web Services"
   kind = "cloud"
 }
-resource "%[1]s_credential" "test2" {
+resource "%[1]s_credential" "%[5]s" {
   name            = "%[2]s"
   description	  = "%[2]s"
-  organization    = %[1]s_organization.test.id
-  credential_type = data.%[1]s_credential_type.test2.id
+  organization    = %[1]s_organization.%[3]s.id
+  credential_type = data.%[1]s_credential_type.%[5]s.id
   inputs = jsonencode({
     "password" : "%[2]s",
     "username" : "%[2]s"
   })
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name        = "%[2]s"
   job_type    = "run"
-  project     = %[1]s_project.test.id
+  project     = %[1]s_project.%[3]s.id
   playbook    = "%[2]s"
+  inventory   = %[1]s_inventory.%[3]s.id
+  ask_credential_on_launch = true
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[3]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node_credential" "test" {
-  credential_ids  = [ %[1]s_credential.test1.id, %[1]s_credential.test2.id ]
-  id = %[1]s_workflow_job_template_job_node.test.id
+resource "%[1]s_workflow_job_template_job_node_credential" "%[3]s" {
+  credential_ids  = [ %[1]s_credential.%[4]s.id, %[1]s_credential.%[5]s.id ]
+  id = %[1]s_workflow_job_template_job_node.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }

--- a/internal/provider/resource_workflow_job_template_job_node_credential_test.go
+++ b/internal/provider/resource_workflow_job_template_job_node_credential_test.go
@@ -92,6 +92,7 @@ resource "%[1]s_job_template" "%[3]s" {
   inventory   = %[1]s_inventory.%[3]s.id
   playbook    = "%[2]s"
   ask_credential_on_launch = true
+  ask_inventory_on_launch  = true
 }
 resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
@@ -162,6 +163,7 @@ resource "%[1]s_job_template" "%[3]s" {
   playbook    = "%[2]s"
   inventory   = %[1]s_inventory.%[3]s.id
   ask_credential_on_launch = true
+  ask_inventory_on_launch  = true
 }
 resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"

--- a/internal/provider/resource_workflow_job_template_job_node_test.go
+++ b/internal/provider/resource_workflow_job_template_job_node_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWkflwJobTemplJobNodeResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
@@ -22,50 +23,50 @@ func TestAccWkflwJobTemplJobNodeResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplJobNodeResource1Config(),
+				Config: testAccWkflwJobTemplJobNodeResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("unified_job_template"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWkflwJobTemplJobNodeResource2Config(),
+				Config: testAccWkflwJobTemplJobNodeResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("unified_job_template"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_job_node.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
@@ -75,71 +76,71 @@ func TestAccWkflwJobTemplJobNodeResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplJobNodeResource1Config() string {
+func testAccWkflwJobTemplJobNodeResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[3]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[3]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName)
 }
 
-func testAccWkflwJobTemplJobNodeResource2Config() string {
+func testAccWkflwJobTemplJobNodeResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      = "%[2]s"
-  inventory = %[1]s_inventory.test.id
-  project   = %[1]s_project.test.id
+  inventory = %[1]s_inventory.%[3]s.id
+  project   = %[1]s_project.%[3]s.id
   playbook  = "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test" {
-  unified_job_template     = %[1]s_job_template.test.id
-  workflow_job_template_id = %[1]s_workflow_job_template.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[3]s" {
+  unified_job_template     = %[1]s_job_template.%[3]s.id
+  workflow_job_template_id = %[1]s_workflow_job_template.%[3]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName)
 }

--- a/internal/provider/resource_workflow_job_template_node_always_test.go
+++ b/internal/provider/resource_workflow_job_template_node_always_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWkflwJobTemplJobNodeAlwaysResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,50 +24,50 @@ func TestAccWkflwJobTemplJobNodeAlwaysResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplJobNodeAlwaysResource1Config(),
+				Config: testAccWkflwJobTemplJobNodeAlwaysResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_always.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_always.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_always.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_always.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("always_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_always.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_always.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWkflwJobTemplJobNodeAlwaysResource2Config(),
+				Config: testAccWkflwJobTemplJobNodeAlwaysResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_always.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_always.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test4", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"d"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_always.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_always.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("always_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test5", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"e"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_always.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_always.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("always_ids"),
 						StringListCompare,
 					),
@@ -76,95 +77,95 @@ func TestAccWkflwJobTemplJobNodeAlwaysResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplJobNodeAlwaysResource1Config() string {
+func testAccWkflwJobTemplJobNodeAlwaysResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[3]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test1" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test2" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_node_always" "test" {
-  id              = %[1]s_workflow_job_template_job_node.test1.id
-  always_ids = [%[1]s_workflow_job_template_job_node.test2.id]
+resource "%[1]s_workflow_job_template_node_always" "%[3]s" {
+  id              = %[1]s_workflow_job_template_job_node.%[4]s.id
+  always_ids = [%[1]s_workflow_job_template_job_node.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }
 
-func testAccWkflwJobTemplJobNodeAlwaysResource2Config() string {
+func testAccWkflwJobTemplJobNodeAlwaysResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      = "%[2]s"
-  inventory = %[1]s_inventory.test.id
-  project   = %[1]s_project.test.id
+  inventory = %[1]s_inventory.%[3]s.id
+  project   = %[1]s_project.%[3]s.id
   playbook  = "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test3" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test4" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test5" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[6]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_node_always" "test" {
-  id              = %[1]s_workflow_job_template_job_node.test3.id
-  always_ids = [%[1]s_workflow_job_template_job_node.test4.id, %[1]s_workflow_job_template_job_node.test5.id]
+resource "%[1]s_workflow_job_template_node_always" "%[3]s" {
+  id              = %[1]s_workflow_job_template_job_node.%[4]s.id
+  always_ids = [%[1]s_workflow_job_template_job_node.%[5]s.id, %[1]s_workflow_job_template_job_node.%[6]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"c", rName+"d", rName+"e")
 }

--- a/internal/provider/resource_workflow_job_template_node_failure_test.go
+++ b/internal/provider/resource_workflow_job_template_node_failure_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWkflwJobTemplJobNodeFailureResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,50 +24,50 @@ func TestAccWkflwJobTemplJobNodeFailureResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplJobNodeFailureResource1Config(),
+				Config: testAccWkflwJobTemplJobNodeFailureResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_failure.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_failure.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_failure.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_failure.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("failure_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_failure.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_failure.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWkflwJobTemplJobNodeFailureResource2Config(),
+				Config: testAccWkflwJobTemplJobNodeFailureResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_failure.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_failure.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test4", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"d"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_failure.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_failure.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("failure_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test5", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"e"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_failure.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_failure.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("failure_ids"),
 						StringListCompare,
 					),
@@ -76,95 +77,95 @@ func TestAccWkflwJobTemplJobNodeFailureResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplJobNodeFailureResource1Config() string {
+func testAccWkflwJobTemplJobNodeFailureResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[3]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test1" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test2" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_node_failure" "test" {
-  id              = %[1]s_workflow_job_template_job_node.test1.id
-  failure_ids = [%[1]s_workflow_job_template_job_node.test2.id]
+resource "%[1]s_workflow_job_template_node_failure" "%[3]s" {
+  id              = %[1]s_workflow_job_template_job_node.%[4]s.id
+  failure_ids = [%[1]s_workflow_job_template_job_node.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }
 
-func testAccWkflwJobTemplJobNodeFailureResource2Config() string {
+func testAccWkflwJobTemplJobNodeFailureResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      = "%[2]s"
-  inventory = %[1]s_inventory.test.id
-  project   = %[1]s_project.test.id
+  inventory = %[1]s_inventory.%[3]s.id
+  project   = %[1]s_project.%[3]s.id
   playbook  = "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test3" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test4" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test5" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[6]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_node_failure" "test" {
-  id              = %[1]s_workflow_job_template_job_node.test3.id
-  failure_ids = [%[1]s_workflow_job_template_job_node.test4.id, %[1]s_workflow_job_template_job_node.test5.id]
+resource "%[1]s_workflow_job_template_node_failure" "%[3]s" {
+  id              = %[1]s_workflow_job_template_job_node.%[4]s.id
+  failure_ids = [%[1]s_workflow_job_template_job_node.%[5]s.id, %[1]s_workflow_job_template_job_node.%[6]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"c", rName+"d", rName+"e")
 }

--- a/internal/provider/resource_workflow_job_template_node_label_test.go
+++ b/internal/provider/resource_workflow_job_template_node_label_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWkflwJobTemplJobNodeLabelResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,33 +24,33 @@ func TestAccWkflwJobTemplJobNodeLabelResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplJobNodeLabelResource1Config(),
+				Config: testAccWkflwJobTemplJobNodeLabelResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_label.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_label.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_label.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_label.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("label_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_label.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_label.%s", configprefix.Prefix, rName+"d"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_label.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_label.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("label_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_label.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_label.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -57,57 +58,57 @@ func TestAccWkflwJobTemplJobNodeLabelResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplJobNodeLabelResource1Config() string {
+func testAccWkflwJobTemplJobNodeLabelResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[3]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test1" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test2" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
 
-resource "%[1]s_label" "test1" {
-	organization = %[1]s_organization.test.id
+resource "%[1]s_label" "%[6]s" {
+	organization = %[1]s_organization.%[3]s.id
 	name = "%[2]s-1"
 }
 
-resource "%[1]s_label" "test2" {
-	organization = %[1]s_organization.test.id
+resource "%[1]s_label" "%[7]s" {
+	organization = %[1]s_organization.%[3]s.id
 	name = "%[2]s-2"
 }
 
-resource "%[1]s_workflow_job_template_node_label" "test" {
-  id        = %[1]s_workflow_job_template_job_node.test1.id
-  label_ids = [%[1]s_label.test1.id, %[1]s_label.test2.id]
+resource "%[1]s_workflow_job_template_node_label" "%[3]s" {
+  id        = %[1]s_workflow_job_template_job_node.%[4]s.id
+  label_ids = [%[1]s_label.%[6]s.id, %[1]s_label.%[7]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b", rName+"c", rName+"d")
 }

--- a/internal/provider/resource_workflow_job_template_node_success_test.go
+++ b/internal/provider/resource_workflow_job_template_node_success_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWkflwJobTemplJobNodeSuccessResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,50 +24,50 @@ func TestAccWkflwJobTemplJobNodeSuccessResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplJobNodeSuccessResource1Config(),
+				Config: testAccWkflwJobTemplJobNodeSuccessResource1Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test1", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("success_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_success.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_node_success.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWkflwJobTemplJobNodeSuccessResource2Config(),
+				Config: testAccWkflwJobTemplJobNodeSuccessResource2Config(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test3", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"c"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test4", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"d"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("success_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template_job_node.test5", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_job_node.%s", configprefix.Prefix, rName+"e"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_node_success.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_node_success.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("success_ids"),
 						StringListCompare,
 					),
@@ -76,95 +77,95 @@ func TestAccWkflwJobTemplJobNodeSuccessResource(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplJobNodeSuccessResource1Config() string {
+func testAccWkflwJobTemplJobNodeSuccessResource1Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[3]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test1" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test2" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_node_success" "test" {
-  id              = %[1]s_workflow_job_template_job_node.test1.id
-  success_ids = [%[1]s_workflow_job_template_job_node.test2.id]
+resource "%[1]s_workflow_job_template_node_success" "%[3]s" {
+  id              = %[1]s_workflow_job_template_job_node.%[4]s.id
+  success_ids = [%[1]s_workflow_job_template_job_node.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }
 
-func testAccWkflwJobTemplJobNodeSuccessResource2Config() string {
+func testAccWkflwJobTemplJobNodeSuccessResource2Config(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[3]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[3]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[3]s" {
   name      = "%[2]s"
-  inventory = %[1]s_inventory.test.id
-  project   = %[1]s_project.test.id
+  inventory = %[1]s_inventory.%[3]s.id
+  project   = %[1]s_project.%[3]s.id
   playbook  = "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[3]s.id
+  organization             = %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test3" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[4]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test4" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[5]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_job_node" "test5" {
-  unified_job_template     	= %[1]s_job_template.test.id
-  workflow_job_template_id 	= %[1]s_workflow_job_template.test.id
-  inventory 				= %[1]s_inventory.test.id
+resource "%[1]s_workflow_job_template_job_node" "%[6]s" {
+  unified_job_template     	= %[1]s_job_template.%[3]s.id
+  workflow_job_template_id 	= %[1]s_workflow_job_template.%[3]s.id
+  inventory 				= %[1]s_inventory.%[3]s.id
 }
-resource "%[1]s_workflow_job_template_node_success" "test" {
-  id              = %[1]s_workflow_job_template_job_node.test3.id
-  success_ids = [%[1]s_workflow_job_template_job_node.test4.id, %[1]s_workflow_job_template_job_node.test5.id]
+resource "%[1]s_workflow_job_template_node_success" "%[3]s" {
+  id              = %[1]s_workflow_job_template_job_node.%[4]s.id
+  success_ids = [%[1]s_workflow_job_template_job_node.%[5]s.id, %[1]s_workflow_job_template_job_node.%[6]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"c", rName+"d", rName+"e")
 }

--- a/internal/provider/resource_workflow_job_template_notification_template_approvals_test.go
+++ b/internal/provider/resource_workflow_job_template_notification_template_approvals_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWorkflowJobTemplNotifApprovalsResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,52 +24,52 @@ func TestAccWorkflowJobTemplNotifApprovalsResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowJobTemplNotifApprovals1ResourceConfig(),
+				Config: testAccWorkflowJobTemplNotifApprovals1ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateWorkflowJobTemplateID(fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateWorkflowJobTemplateID(fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("workflow_job_template_id"),
 			},
 			{
-				Config: testAccWorkflowJobTemplNotifApprovals2ResourceConfig(),
+				Config: testAccWorkflowJobTemplNotifApprovals2ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_approvals.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
@@ -78,19 +79,19 @@ func TestAccWorkflowJobTemplNotifApprovalsResource(t *testing.T) {
 	})
 }
 
-func testAccWorkflowJobTemplNotifApprovals1ResourceConfig() string {
+func testAccWorkflowJobTemplNotifApprovals1ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name        = "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_notification_template" "test" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -129,26 +130,26 @@ resource "%[1]s_notification_template" "test" {
     }
   })
 }
-resource "%[1]s_workflow_job_template_notification_template_approvals" "test" {
-  workflow_job_template_id    = %[1]s_workflow_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test.id]
+resource "%[1]s_workflow_job_template_notification_template_approvals" "%[3]s" {
+  workflow_job_template_id    = %[1]s_workflow_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a")
 }
 
-func testAccWorkflowJobTemplNotifApprovals2ResourceConfig() string {
+func testAccWorkflowJobTemplNotifApprovals2ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name        = "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_notification_template" "test" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s-2"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -187,10 +188,10 @@ resource "%[1]s_notification_template" "test" {
     }
   })
 }
-resource "%[1]s_notification_template" "test2" {
+resource "%[1]s_notification_template" "%[5]s" {
   name              = "%[2]s-3"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -229,9 +230,9 @@ resource "%[1]s_notification_template" "test2" {
     }
   })
 }
-resource "%[1]s_workflow_job_template_notification_template_approvals" "test" {
-  workflow_job_template_id    = %[1]s_workflow_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test.id, %[1]s_notification_template.test2.id]
+resource "%[1]s_workflow_job_template_notification_template_approvals" "%[3]s" {
+  workflow_job_template_id    = %[1]s_workflow_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id, %[1]s_notification_template.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }

--- a/internal/provider/resource_workflow_job_template_notification_template_error_test.go
+++ b/internal/provider/resource_workflow_job_template_notification_template_error_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWorkflowJobTemplNotifErrorResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,52 +24,52 @@ func TestAccWorkflowJobTemplNotifErrorResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowJobTemplNotifError1ResourceConfig(),
+				Config: testAccWorkflowJobTemplNotifError1ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateWorkflowJobTemplateID(fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateWorkflowJobTemplateID(fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("workflow_job_template_id"),
 			},
 			{
-				Config: testAccWorkflowJobTemplNotifError2ResourceConfig(),
+				Config: testAccWorkflowJobTemplNotifError2ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_error.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_error.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
@@ -78,19 +79,19 @@ func TestAccWorkflowJobTemplNotifErrorResource(t *testing.T) {
 	})
 }
 
-func testAccWorkflowJobTemplNotifError1ResourceConfig() string {
+func testAccWorkflowJobTemplNotifError1ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name        = "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_notification_template" "test" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -129,26 +130,26 @@ resource "%[1]s_notification_template" "test" {
     }
   })
 }
-resource "%[1]s_workflow_job_template_notification_template_error" "test" {
-  workflow_job_template_id    = %[1]s_workflow_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test.id]
+resource "%[1]s_workflow_job_template_notification_template_error" "%[3]s" {
+  workflow_job_template_id    = %[1]s_workflow_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a")
 }
 
-func testAccWorkflowJobTemplNotifError2ResourceConfig() string {
+func testAccWorkflowJobTemplNotifError2ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name        = "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_notification_template" "test" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s-2"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -187,10 +188,10 @@ resource "%[1]s_notification_template" "test" {
     }
   })
 }
-resource "%[1]s_notification_template" "test2" {
+resource "%[1]s_notification_template" "%[5]s" {
   name              = "%[2]s-3"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -229,9 +230,9 @@ resource "%[1]s_notification_template" "test2" {
     }
   })
 }
-resource "%[1]s_workflow_job_template_notification_template_error" "test" {
-  workflow_job_template_id    = %[1]s_workflow_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test.id, %[1]s_notification_template.test2.id]
+resource "%[1]s_workflow_job_template_notification_template_error" "%[3]s" {
+  workflow_job_template_id    = %[1]s_workflow_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id, %[1]s_notification_template.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }

--- a/internal/provider/resource_workflow_job_template_notification_template_started_test.go
+++ b/internal/provider/resource_workflow_job_template_notification_template_started_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccWorkflowJobTemplNotifStartedResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	StringListCompare := &compareStringInList{}
 	resource.Test(t, resource.TestCase{
@@ -23,52 +24,52 @@ func TestAccWorkflowJobTemplNotifStartedResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowJobTemplNotifStarted1ResourceConfig(),
+				Config: testAccWorkflowJobTemplNotifStarted1ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 				},
 			},
 			{
-				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix),
+				ResourceName:                         fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateIdFunc:                    importStateWorkflowJobTemplateID(fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix)),
+				ImportStateIdFunc:                    importStateWorkflowJobTemplateID(fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName)),
 				ImportStateVerifyIdentifierAttribute: ("workflow_job_template_id"),
 			},
 			{
-				Config: testAccWorkflowJobTemplNotifStarted2ResourceConfig(),
+				Config: testAccWorkflowJobTemplNotifStarted2ResourceConfig(rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("workflow_job_template_id"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"a"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_notification_template.test2", configprefix.Prefix),
+						fmt.Sprintf("%s_notification_template.%s", configprefix.Prefix, rName+"b"),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_notification_template_started.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_notification_template_started.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("notif_template_ids"),
 						StringListCompare,
 					),
@@ -78,19 +79,19 @@ func TestAccWorkflowJobTemplNotifStartedResource(t *testing.T) {
 	})
 }
 
-func testAccWorkflowJobTemplNotifStarted1ResourceConfig() string {
+func testAccWorkflowJobTemplNotifStarted1ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name        = "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_notification_template" "test" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -129,26 +130,26 @@ resource "%[1]s_notification_template" "test" {
     }
   })
 }
-resource "%[1]s_workflow_job_template_notification_template_started" "test" {
-  workflow_job_template_id    = %[1]s_workflow_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test.id]
+resource "%[1]s_workflow_job_template_notification_template_started" "%[3]s" {
+  workflow_job_template_id    = %[1]s_workflow_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a")
 }
 
-func testAccWorkflowJobTemplNotifStarted2ResourceConfig() string {
+func testAccWorkflowJobTemplNotifStarted2ResourceConfig(rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[3]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[3]s" {
   name        = "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[3]s.id
 }
-resource "%[1]s_notification_template" "test" {
+resource "%[1]s_notification_template" "%[4]s" {
   name              = "%[2]s-2"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -187,10 +188,10 @@ resource "%[1]s_notification_template" "test" {
     }
   })
 }
-resource "%[1]s_notification_template" "test2" {
+resource "%[1]s_notification_template" "%[5]s" {
   name              = "%[2]s-3"
   notification_type = "slack"
-  organization      = %[1]s_organization.test.id
+  organization      = %[1]s_organization.%[3]s.id
   notification_configuration = jsonencode({
     channels  = ["#channel1", "#channel1"]
     hex_color = ""
@@ -229,9 +230,9 @@ resource "%[1]s_notification_template" "test2" {
     }
   })
 }
-resource "%[1]s_workflow_job_template_notification_template_started" "test" {
-  workflow_job_template_id    = %[1]s_workflow_job_template.test.id
-  notif_template_ids = [%[1]s_notification_template.test.id, %[1]s_notification_template.test2.id]
+resource "%[1]s_workflow_job_template_notification_template_started" "%[3]s" {
+  workflow_job_template_id    = %[1]s_workflow_job_template.%[3]s.id
+  notif_template_ids = [%[1]s_notification_template.%[4]s.id, %[1]s_notification_template.%[5]s.id]
 }
-  `, configprefix.Prefix, acctest.RandString(5))
+  `, configprefix.Prefix, acctest.RandString(5), rName, rName+"a", rName+"b")
 }

--- a/internal/provider/resource_workflow_job_template_survey_spec_test.go
+++ b/internal/provider/resource_workflow_job_template_survey_spec_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccWkflwJobTemplateSurveySpec(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	wkflkJtName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{
@@ -25,27 +26,27 @@ func TestAccWkflwJobTemplateSurveySpec(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWkflwJobTemplateSurveySpecConfig(wkflkJtName),
+				Config: testAccWkflwJobTemplateSurveySpecConfig(wkflkJtName, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_survey_spec.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_survey_spec.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact("test description"),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template_survey_spec.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_survey_spec.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
 						compare.ValuesSame(),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_survey_spec.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_survey_spec.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(""),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template_survey_spec.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template_survey_spec.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("spec"),
 						knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
@@ -95,7 +96,7 @@ func TestAccWkflwJobTemplateSurveySpec(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template_survey_spec.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template_survey_spec.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -103,42 +104,42 @@ func TestAccWkflwJobTemplateSurveySpec(t *testing.T) {
 	})
 }
 
-func testAccWkflwJobTemplateSurveySpecConfig(workflow_template_name string) string {
+func testAccWkflwJobTemplateSurveySpecConfig(workflow_template_name string, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[5]s" {
 	name = "%[2]s"
 }
 
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[5]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[5]s.id
 }
 
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[5]s" {
 	name = "%[3]s"
-	organization = %[1]s_organization.test.id
+	organization = %[1]s_organization.%[5]s.id
 	allow_override = true
 	scm_type = "git"
 	scm_url = "fake"
 }
 
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[5]s" {
   job_type  = "run"
   name      = "%[4]s"
   ask_inventory_on_launch = true
-  project   = %[1]s_project.test.id
+  project   = %[1]s_project.%[5]s.id
   playbook  = "hello_world.yml"
 }
 
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[5]s" {
   name                     = "%[2]s"
-  inventory                = %[1]s_inventory.test.id
-  organization             = %[1]s_organization.test.id
+  inventory                = %[1]s_inventory.%[5]s.id
+  organization             = %[1]s_organization.%[5]s.id
 }
 
-resource "%[1]s_workflow_job_template_survey_spec" "test" {
+resource "%[1]s_workflow_job_template_survey_spec" "%[5]s" {
   description = "test description"
-  id          = %[1]s_workflow_job_template.test.id
+  id          = %[1]s_workflow_job_template.%[5]s.id
   name        = ""
   spec = [
     {
@@ -175,5 +176,5 @@ resource "%[1]s_workflow_job_template_survey_spec" "test" {
     },
   ]
 }
-`, configprefix.Prefix, acctest.RandStringFromCharSet(5, acctest.CharSetAlpha), acctest.RandStringFromCharSet(5, acctest.CharSetAlpha), workflow_template_name)
+`, configprefix.Prefix, acctest.RandStringFromCharSet(5, acctest.CharSetAlpha), acctest.RandStringFromCharSet(5, acctest.CharSetAlpha), workflow_template_name, rName)
 }

--- a/internal/provider/resource_workflow_job_template_test.go
+++ b/internal/provider/resource_workflow_job_template_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccWorkflowJobTemplateResource(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+	rName2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 	IdCompare := &compareTwoValuesAsStrings{}
 	resource1 := WorkflowJobTemplateAPIModel{
 		Name: "test-workflow-job-template" + acctest.RandString(5),
@@ -30,58 +32,58 @@ func TestAccWorkflowJobTemplateResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkflowJobTemplateResource1Config(resource1),
+				Config: testAccWorkflowJobTemplateResource1Config(resource1, rName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource1.Name),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
 				},
 			},
 			{
-				ResourceName:      fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+				ResourceName:      fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccWorkflowJobTemplateResource2Config(resource2),
+				Config: testAccWorkflowJobTemplateResource2Config(resource2, rName2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("name"),
 						knownvalue.StringExact(resource2.Name),
 					),
 					statecheck.ExpectKnownValue(
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("description"),
 						knownvalue.StringExact(resource2.Description),
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_inventory.test", configprefix.Prefix),
+						fmt.Sprintf("%s_inventory.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("inventory"),
 						IdCompare,
 					),
 					statecheck.CompareValuePairs(
-						fmt.Sprintf("%s_organization.test", configprefix.Prefix),
+						fmt.Sprintf("%s_organization.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("id"),
-						fmt.Sprintf("%s_workflow_job_template.test", configprefix.Prefix),
+						fmt.Sprintf("%s_workflow_job_template.%s", configprefix.Prefix, rName2),
 						tfjsonpath.New("organization"),
 						IdCompare,
 					),
@@ -91,63 +93,63 @@ func TestAccWorkflowJobTemplateResource(t *testing.T) {
 	})
 }
 
-func testAccWorkflowJobTemplateResource1Config(resource WorkflowJobTemplateAPIModel) string {
+func testAccWorkflowJobTemplateResource1Config(resource WorkflowJobTemplateAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[4]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[4]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[4]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[4]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[4]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[4]s" {
   name      				= "%[2]s"
   ask_inventory_on_launch 	= true
-  project   				= %[1]s_project.test.id
+  project   				= %[1]s_project.%[4]s.id
   playbook  				= "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[4]s" {
   name         = "%[3]s"
-  inventory    = %[1]s_inventory.test.id
-  organization = %[1]s_organization.test.id
+  inventory    = %[1]s_inventory.%[4]s.id
+  organization = %[1]s_organization.%[4]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, rName)
 }
 
-func testAccWorkflowJobTemplateResource2Config(resource WorkflowJobTemplateAPIModel) string {
+func testAccWorkflowJobTemplateResource2Config(resource WorkflowJobTemplateAPIModel, rName string) string {
 	return fmt.Sprintf(`
-resource "%[1]s_organization" "test" {
+resource "%[1]s_organization" "%[5]s" {
   name        = "%[2]s"
 }
-resource "%[1]s_inventory" "test" {
+resource "%[1]s_inventory" "%[5]s" {
   name         = "%[2]s"
-  organization = %[1]s_organization.test.id
+  organization = %[1]s_organization.%[5]s.id
 }
-resource "%[1]s_project" "test" {
+resource "%[1]s_project" "%[5]s" {
   name         		= "%[2]s"
-  organization 		= %[1]s_organization.test.id
+  organization 		= %[1]s_organization.%[5]s.id
   scm_type     		= "git"
   scm_url      		= "git@github.com:user/repo.git"
   allow_override 	= true
 }
-resource "%[1]s_job_template" "test" {
+resource "%[1]s_job_template" "%[5]s" {
   name      = "%[2]s"
-  inventory = %[1]s_inventory.test.id
-  project   = %[1]s_project.test.id
+  inventory = %[1]s_inventory.%[5]s.id
+  project   = %[1]s_project.%[5]s.id
   playbook  = "test.yml"
 }
-resource "%[1]s_workflow_job_template" "test" {
+resource "%[1]s_workflow_job_template" "%[5]s" {
   name         = "%[3]s"
   description  = "%[4]s"
-  inventory    = %[1]s_inventory.test.id
-  organization = %[1]s_organization.test.id
+  inventory    = %[1]s_inventory.%[5]s.id
+  organization = %[1]s_organization.%[5]s.id
 }
-  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description)
+  `, configprefix.Prefix, acctest.RandString(5), resource.Name, resource.Description, rName)
 }


### PR DESCRIPTION
1. Change the resource*test.go files to generate random names for any resources they create so that when the github workflow actions runs tests in parallel via matrix setup for different terraform versions - the tests don't step on each other if 2 executions of the test create, for example, an awx_inventory.test. 
2. Alter the resource_workflow_job_template_survey_spec_test.go to pass by setting attributes on job_template that were missed.